### PR TITLE
[SE-4490] Fix devstack setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ git clone git@gitlab.com:opencraft/client/campus/campus-devstack.git
 2. Provision the devstack:
 
 ```terminal
-vagrant plugin update vagrant-vbguest
+vagrant plugin install vagrant-vbguest --plugin-version 0.21
 vagrant up
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -172,9 +172,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ['modifyvm', :id, '--nictype1', 'virtio']
   end
 
-  # Use vagrant-vbguest plugin to make sure Guest Additions are in sync
-  config.vbguest.auto_reboot = true
-  config.vbguest.auto_update = true
+  # Disable auto-update as it causes plugin failures
+  config.vbguest.auto_update = false
 
   # Assume that the base box has the edx_ansible role installed
   # We can then tell the Vagrant instance to update itself.

--- a/campus-vars.yml
+++ b/campus-vars.yml
@@ -27,7 +27,7 @@ forum_source_repo: https://github.com/edx-olive/cs_comments_service.git
 forum_version: opencraft-release/ginkgo.2-campus
 
 ANALYTICS_API_VERSION: open-release/ginkgo.2
-DISCOVERY_VERSION: open-release/ginkgo.master
+DISCOVERY_VERSION: opencraft-release/ginkgo.2-campus
 ECOMMERCE_VERSION: open-release/ginkgo.2
 INSIGHTS_VERSION: open-release/ginkgo.master  # bower dependency bug in ginkgo.2
 NOTIFIER_VERSION: open-release/ginkgo.2


### PR DESCRIPTION
The devstack setup started to break lately. The reason behind it is the outdated infrastructure components (like MongoDB) and Python version it is using. Also, discovery service started to fail due to python requirements issues.

This PR fixes the documentation update of which `vagrant-vbguest` version should be used, disables the vbguest auto-update and fixes the discovery service version.

**Dependencies**: None

**Sandbox URL**: N/A

**Merge deadline**: ASAP

**Testing instructions**:

1. Proofread
1. Setup repository as it is described in the README

**Author notes and concerns**:

N/A

**Reviewers**
- [ ] @jvdm